### PR TITLE
Update URL in io.openems.edge.predictor.persistencemodel.html

### DIFF
--- a/openems/latest/edge/device_service.adoc.d/io.openems.edge.predictor.persistencemodel.html
+++ b/openems/latest/edge/device_service.adoc.d/io.openems.edge.predictor.persistencemodel.html
@@ -190,7 +190,7 @@
 <p>Predicts values using the 'same-as-last-day' approach.</p>
 </div>
 <div class="paragraph">
-<p><a href="https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.predictor.holtwinters">Source Code <span class="icon"><i class="fa fa-github"></i></span></a></p>
+<p><a href="https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.predictor.persistencemodel">Source Code <span class="icon"><i class="fa fa-github"></i></span></a></p>
 </div>
 </article>
   </main>


### PR DESCRIPTION
The URL in the paragraph was broken (See end HOLTWINTERS): paragraph from https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.predictor.holtwinters 

changed to:
https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.predictor.persistencemodel